### PR TITLE
Make `google()` ahead of `jcenter()`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ buildScan {
 
 subprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 


### PR DESCRIPTION
Putting `jcenter()` ahead of `google()` might cause some issues in `gradle/gradle` 
repository's smoke tests. This PR puts `google()` at first.