### PR TITLE
Bump scan plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.gradle.build-scan' version '1.10.2'
+    id 'com.gradle.build-scan' version '1.16'
 }
 
 buildScan {


### PR DESCRIPTION
Gradle > 4.10 is not compatible with scan plugin < 1.13.

This breaks https://github.com/gradle/android-relocation-test, which in turn breaks `AndroidCachingSmokeTest`